### PR TITLE
Update README.md (adding salat-next web app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 
 ## Web Apps
 
+- [Salat-next](https://github.com/kafiln/salat-next): Prayer times in Morocco by cities (scraped from The Ministry of Endowments and Islamic Affairs) [Preview](https://salat.vercel.app/daily/casablanca).
 - [Quran](https://github.com/quran/quran.com-frontend-v2): The official source code repository for [Quran.com](https://Quran.com)
 - [Quran Reader](https://github.com/mohdovais/quran): Quran Reader in Arabic.
 - [Time For Salah Website](https://github.com/AbdulMalikDev/TimeForSalahWebsite): A Muslim Prayer Timing Website build with pure JavaScript.


### PR DESCRIPTION
Prayer time in Morocco by cities with many features like getting the prayer time by day or by month (scraped from The Ministry of Endowments and Islamic Affairs) Preview : https://salat.vercel.app/daily/casablanca.